### PR TITLE
fix(executor): mount writable tmpfs over ~/.cache (alt to #135 env redirect)

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -138,17 +138,13 @@ echo "phase=execution" >> "$PHASE_FILE"
 START_EXEC=$(get_time_ms)
 echo "execution_start_ms=$START_EXEC" >> "$PHASE_FILE"
 
-# Redirect library cache/config dirs onto the writable /tmp tmpfs. The root
-# filesystem is mounted --read-only and the sandbox user's HOME (/home/sandbox)
-# lives there, so any library that wants $HOME/.cache (ezdxf, matplotlib,
-# fontconfig, ...) would otherwise fail to create it and warn on every run.
-# gosu preserves the environment, so both vars reach the Python process below.
-# Created as container root, so hand ownership to the sandbox user (uid 1000)
-# the same way the uv cache dir is above, since code runs unprivileged.
-export XDG_CACHE_HOME=/tmp/.cache
-export MPLCONFIGDIR=/tmp/.cache/matplotlib
-mkdir -p "$XDG_CACHE_HOME" "$MPLCONFIGDIR"
-chown -R sandbox:sandbox "$XDG_CACHE_HOME"
+# The sandbox user's ~/.cache is a writable tmpfs mount (set up in the container
+# run args with mode 1777), so libraries that cache under $HOME/.cache (ezdxf,
+# fontconfig, matplotlib, Hugging Face, torch, ...) work under the --read-only
+# root filesystem with no redirection. matplotlib also keeps a *config* dir
+# outside .cache; point it into the writable cache so it does not fall back to a
+# temp dir and warn. gosu preserves the environment, so this reaches Python.
+export MPLCONFIGDIR=/home/sandbox/.cache/matplotlib
 
 # Drop privileges and run user code as sandbox user
 # Using exec replaces this process, so we need a wrapper to capture timing.

--- a/docs/getting-started/configuration.md
+++ b/docs/getting-started/configuration.md
@@ -89,6 +89,7 @@ container_limits:
   nproc_hard: 50
   fsize: 104857600        # 100MB max file size
   tmpfs_size: "100m"
+  cache_tmpfs_size: "256m"   # writable ~/.cache (RAM-backed)
 
 # ==============================================================================
 # JOB TYPES
@@ -231,6 +232,7 @@ When you define a job type, Tako VM builds a Docker image with the specified pac
 | `nproc_soft/hard` | Process count | 50 | 10-1000 |
 | `fsize` | Max file size | 100MB | 1MB-1GB |
 | `tmpfs_size` | /tmp size | 100m | 10m-2g |
+| `cache_tmpfs_size` | writable ~/.cache size (RAM-backed) | 256m | 10m-2g |
 
 ## Validating Configuration
 

--- a/docs/guide/filesystem-and-caches.md
+++ b/docs/guide/filesystem-and-caches.md
@@ -14,18 +14,21 @@ models without hitting "read-only filesystem" errors.
 
 | Path | Type | Writable? | Persists between runs? |
 |------|------|-----------|------------------------|
-| `/` (root, incl. `/home/sandbox`) | image layers | **No** (read-only) | n/a |
+| `/` (root, incl. most of `/home/sandbox`) | image layers | **No** (read-only) | n/a |
+| `/home/sandbox/.cache` | tmpfs (RAM-backed) | Yes | **No** wiped on exit |
 | `/tmp` | tmpfs (RAM-backed) | Yes | **No** wiped on exit |
 | `/output` | bind mount | Yes | Collected as artifacts |
 | `/input`, `/code` | bind mount | No (read-only) | n/a |
 
 Two consequences matter for library behavior:
 
-- The sandbox user's home, `/home/sandbox`, lives on the **read-only** root. Anything
-  that tries to write under `$HOME` fails.
-- `/tmp` is **RAM-backed and size-capped** (100 MB default, 300 MB while installing
-  dependencies) and is **wiped when the container exits**. It is scratch space, not
-  storage.
+- The sandbox user's home, `/home/sandbox`, is on the **read-only** root, **except**
+  `~/.cache`, which is a writable tmpfs mount (see below). Writes elsewhere under
+  `$HOME` (e.g. `~/.config`, `~/.local`) fail.
+- The writable tmpfs areas (`~/.cache`, `/tmp`) are **RAM-backed, size-capped, and
+  wiped when the container exits**. `/tmp` defaults to 100 MB (300 MB while installing
+  dependencies); `~/.cache` defaults to 256 MB (`container_limits.cache_tmpfs_size`).
+  They are scratch space, not storage.
 
 > Today each container is single-use, so nothing written at runtime survives. Durable,
 > per-agent workspaces are on the roadmap, see the project direction in the README.
@@ -41,16 +44,27 @@ resources. On a read-only `$HOME` those writes fail, and you would see warnings 
 Cannot create cache home directory: '/home/sandbox/.cache/ezdxf', cache files will not be saved.
 ```
 
-Tako VM avoids this by pointing the cache/config directories at the writable `/tmp`
-tmpfs before running your code (in `docker/entrypoint.sh`):
+Tako VM avoids this by mounting a writable tmpfs **over `~/.cache` itself**, so the
+conventional path works without any redirection:
 
-```sh
-export XDG_CACHE_HOME=/tmp/.cache       # ezdxf, fontconfig, most XDG-aware libs
-export MPLCONFIGDIR=/tmp/.cache/matplotlib   # matplotlib uses its own variable
+```
+--tmpfs=/home/sandbox/.cache:rw,nosuid,mode=1777,size=<cache_tmpfs_size>
 ```
 
-This is handled automatically, no action needed for these libraries. The cache lives
-in `/tmp`, so it is recomputed on the next run (it is an optimization, not stored data).
+`mode=1777` lets the unprivileged sandbox user write to it (the container drops
+`CAP_CHOWN`, so a `chown` would not work). Because the cache is at its standard
+location, *any* library that writes under `~/.cache` works, including ones that ignore
+`XDG_CACHE_HOME`. The only knob you may want is the size:
+
+```yaml
+container_limits:
+  cache_tmpfs_size: "256m"   # default; RAM-backed, counts against memory_limit
+```
+
+This is handled automatically, no action needed for these libraries. The cache lives in
+the tmpfs, so it is recomputed on the next run (it is an optimization, not stored data).
+matplotlib also keeps a *config* dir outside `~/.cache`; the entrypoint points
+`MPLCONFIGDIR` into the writable cache so matplotlib does not warn.
 
 ## Loading ML models (Hugging Face, PyTorch, NLTK, ...)
 
@@ -60,10 +74,10 @@ library downloads weights and writes them under `$HOME/.cache` (or `HF_HOME`), t
 loads them from that path. There is no in-memory fallback, so an unwritable cache is a
 hard failure, not a warning.
 
-Redirecting the cache to `/tmp` does **not** reliably fix this, `/tmp` is too small for
-a multi-hundred-MB model, is RAM-backed (so it competes with your job's memory limit),
-and is wiped every run (so the model re-downloads each time). Network is also disabled
-by default (`--network=none`), so a runtime download often cannot happen at all.
+The writable `~/.cache` tmpfs does **not** reliably fix this: even sized up, it is
+RAM-backed (so a multi-hundred-MB model competes with your job's memory limit) and is
+wiped every run (so the model re-downloads each time). Network is also disabled by
+default (`--network=none`), so a runtime download often cannot happen at all.
 
 The correct approach is to **pre-stage the model so it is present and read-only at
 runtime.** Hugging Face and friends are happy to *load* from a read-only cache, they
@@ -116,6 +130,6 @@ an updated or moved model.
 
 | If you use... | Do this |
 |---------------|---------|
-| matplotlib, ezdxf, fontconfig (cache-for-speed libs) | Nothing, caches are redirected to `/tmp` automatically |
+| matplotlib, ezdxf, fontconfig (cache-for-speed libs) | Nothing, `~/.cache` is a writable tmpfs automatically |
 | Hugging Face / torch / NLTK (download-and-cache libs) | Pre-stage the model (bake into image or read-only volume) and set `HF_HOME` + offline mode |
 | Anything that must write at runtime | Write under `/tmp` (scratch, ephemeral) or `/output` (collected); never expect `$HOME` to be writable |

--- a/tako_vm.yaml.example
+++ b/tako_vm.yaml.example
@@ -82,6 +82,7 @@ container_limits:
   nproc_hard: 50        # Process limit hard (10-1000)
   fsize: 104857600      # Max file size: 100MB (1MB-1GB)
   tmpfs_size: "100m"    # /tmp size (10m-2g)
+  cache_tmpfs_size: "256m"  # writable ~/.cache size (10m-2g); RAM-backed
 
 # =============================================================================
 # Paths

--- a/tako_vm/config.py
+++ b/tako_vm/config.py
@@ -101,24 +101,31 @@ class ContainerLimits(BaseModel):
     # tmpfs size for /tmp (e.g., "100m", "256m", "1g")
     tmpfs_size: str = Field(default="100m")
 
+    # tmpfs size for the sandbox user's ~/.cache (e.g., "256m", "1g"). Mounted
+    # writable over /home/sandbox/.cache so libraries that cache under
+    # $HOME/.cache (ezdxf, matplotlib, fontconfig, Hugging Face, torch, ...) work
+    # under the --read-only root filesystem. RAM-backed, so it counts against the
+    # container memory limit, like /tmp.
+    cache_tmpfs_size: str = Field(default="256m")
+
     # PIDs limit
     pids_limit: int = Field(default=100, ge=10, le=1000)
 
-    @field_validator("tmpfs_size")
+    @field_validator("tmpfs_size", "cache_tmpfs_size")
     @classmethod
     def validate_tmpfs_size(cls, v: str) -> str:
-        """Validate tmpfs size format and bounds."""
+        """Validate a tmpfs size (format and 10m-2g bounds)."""
         v = v.lower().strip()
         if not v:
-            raise ValueError("tmpfs_size cannot be empty")
+            raise ValueError("tmpfs size cannot be empty")
 
         size_mb = _parse_size_to_mb(v, allow_k_and_bytes=True)
 
         # Validate bounds (10MB to 2GB)
         if size_mb < 10:
-            raise ValueError("tmpfs_size must be at least 10m")
+            raise ValueError("tmpfs size must be at least 10m")
         if size_mb > 2048:
-            raise ValueError("tmpfs_size must be at most 2g")
+            raise ValueError("tmpfs size must be at most 2g")
 
         return v
 

--- a/tako_vm/execution/worker.py
+++ b/tako_vm/execution/worker.py
@@ -1425,6 +1425,13 @@ class CodeExecutor:
                 f"--mount=type=bind,source={output_dir.absolute()},target=/output",
                 # Use larger /tmp and allow exec when installing packages (packages go to /tmp/site-packages)
                 f"--tmpfs=/tmp:rw,{'exec' if has_runtime_deps else 'noexec'},nosuid,size={'300m' if has_runtime_deps else limits.tmpfs_size}",
+                # Writable cache for the sandbox user's $HOME/.cache. The root
+                # filesystem is --read-only, so without this any library caching
+                # under ~/.cache (ezdxf, matplotlib, fontconfig, Hugging Face,
+                # torch, ...) fails. mode=1777 lets the dropped sandbox user write
+                # without CAP_CHOWN (which --cap-drop=ALL removes). RAM-backed, so
+                # it counts against --memory like /tmp.
+                f"--tmpfs=/home/sandbox/.cache:rw,{'exec' if has_runtime_deps else 'noexec'},nosuid,mode=1777,size={limits.cache_tmpfs_size}",
             ]
         )
 

--- a/tako_vm/sandbox.py
+++ b/tako_vm/sandbox.py
@@ -624,6 +624,9 @@ class Sandbox:
                 f"--mount=type=bind,source={input_dir.absolute()},target=/input,readonly",
                 f"--mount=type=bind,source={output_dir.absolute()},target=/output",
                 f"--tmpfs=/tmp:rw,exec,nosuid,size={tmp_size}",
+                # Writable $HOME/.cache (see CodeExecutor for the rationale).
+                # mode=1777 lets the dropped sandbox user write without CAP_CHOWN.
+                f"--tmpfs=/home/sandbox/.cache:rw,exec,nosuid,mode=1777,size={limits.cache_tmpfs_size}",
             ]
         )
 


### PR DESCRIPTION
**Draft for side-by-side comparison with the merged cache fix (#135).** Same goal,
different mechanism. Not meant to auto-merge: pick one approach.

## The two approaches

| | **#135 (merged)** | **This PR** |
|---|---|---|
| Mechanism | `entrypoint.sh` exports `XDG_CACHE_HOME`/`MPLCONFIGDIR` -> `/tmp/.cache` | Mount a writable tmpfs **over `~/.cache` itself** in the run args |
| Where caches land | `/tmp` (shared with site-packages etc.) | dedicated `/home/sandbox/.cache` tmpfs |
| Covers libs that ignore `XDG_CACHE_HOME` and hardcode `~/.cache` | ❌ no | ✅ yes (conventional path) |
| Ownership | entrypoint `chown` (needs CAP_CHOWN, which `--cap-drop=ALL` removes) | `mode=1777`, no chown needed |
| Size control | shares `/tmp` budget | own knob: `container_limits.cache_tmpfs_size` (default 256m) |
| Surface | 4-line entrypoint edit | container-arg + config change (worker.py, sandbox.py, config.py) |

## Why I think the tmpfs-over-`~/.cache` mechanism is cleaner

- **Conventional path** -> works for any library that writes under `~/.cache`, not just
  the XDG-aware ones we enumerated.
- **`mode=1777`** lets the unprivileged sandbox user write **without `CAP_CHOWN`**. The
  container runs `--cap-drop=ALL` keeping only SETUID/SETGID (docker.py), so #135's
  entrypoint `chown -R sandbox:sandbox` is on shaky ground; this sidesteps it.
- **Dedicated, independently configurable size** that does not compete with `/tmp`.

## Security

Unchanged posture. The `--read-only` root filesystem stays read-only; this adds one
**bounded, ephemeral** writable mount, the same class of thing as the existing `/tmp`
tmpfs. It does **not** make the image writable. The mount mirrors `/tmp`'s exec policy
(exec only when runtime deps are installed on the server path).

## Scope / honesty

- Applied to **both** execution paths (server `CodeExecutor` and library `Sandbox`) via
  their run-arg builders, so they cannot drift.
- `entrypoint.sh` keeps a single `MPLCONFIGDIR` line, matplotlib's *config* dir lives
  outside `~/.cache`.
- Still does **not** make large ML model downloads persist (`/tmp` and `~/.cache` are
  both RAM-backed and wiped per run). Pre-staging remains the answer for those; see the
  updated `docs/guide/filesystem-and-caches.md`.
- Validated: `ruff` clean, config + isolation/sandbox tests pass (138 passed, 10 skipped).
  **Not** runtime-verified end-to-end, confirming the tmpfs mount + library writes needs
  an executor image rebuild + container run (same deploy caveat as #135).

If we take this, we should revert the #135 entrypoint redirect (this PR already removes it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)