### PR TITLE
docs: standardize Markdown viewer on mo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,6 +62,16 @@ TAKO_VM_SECURITY_MODE=permissive pytest tests/ -v
 tako-vm server --port 8000
 ```
 
+## Markdown Viewing
+
+Use `mo` as the Markdown viewer for local previews and agent workflows:
+
+```bash
+mo README.md docs/
+```
+
+Do not introduce alternate Markdown viewers for repository docs unless there is a specific project need.
+
 ## Code Quality
 
 Linting is handled automatically via a PostToolUse hook (`.claude/hooks/lint.sh`) that runs `ruff check --fix` and `ruff format` on changed Python files. To run manually:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,18 @@ Thanks for your interest in contributing! This guide covers everything you need 
 
 Requirements: Python 3.10+, Docker, and `git`.
 
+For local Markdown previews, use [`mo`](https://github.com/k1LoW/mo) so contributors and agents see the same GitHub-flavored rendering. Install it with Homebrew:
+
+```bash
+brew install k1LoW/tap/mo
+```
+
+Then open Markdown files from the repository root:
+
+```bash
+mo README.md docs/
+```
+
 ```bash
 git clone https://github.com/Tako-Research/TakoVM.git
 cd TakoVM


### PR DESCRIPTION
## Summary
- Document `mo` as the standard Markdown viewer for local previews.
- Add the same convention to `CLAUDE.md` so agent workflows use `mo` consistently.

## Verification
- `git diff --check`
- `uv run --extra docs mkdocs build --strict` *(fails before building: existing `mkdocs.yml` parse error at line 2, column 90 due to the unquoted colon in `site_description`)*
