### PR TITLE
fix(docs): quote site_description so mkdocs.yml parses

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Tako VM
-site_description: Secure Python code execution and job queue infrastructure for AI agents: run untrusted code in gVisor-isolated Docker containers with workers, retries, and replay.
+site_description: "Secure Python code execution and job queue infrastructure for AI agents: run untrusted code in gVisor-isolated Docker containers with workers, retries, and replay."
 site_url: https://tako-research.github.io/TakoVM/
 site_author: Tako VM
 


### PR DESCRIPTION
`site_description` contains an unquoted colon-space ("...for AI agents: run untrusted code..."), which YAML parses as a nested mapping key. mkdocs fails at line 2 with `mapping values are not allowed here`, so **Deploy Docs has failed on every push to main since at least 2026-08-06** and the published docs site is stale by 5+ days.

Quoting the scalar is the whole fix; no other config changes.

```
origin/main  PARSE ERROR: mapping values are not allowed here
fixed        parses OK
```

Found while checking post-merge CI on #153; unrelated to that change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCi216irm5J9XxAW14WGPh
