### PR TITLE
fix(defaults): fail closed on the four remaining pre-audit gaps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ lima-gvisor.yaml           # Lima VM config for macOS dev with gVisor
 
 ## Key Concepts
 
-- **Security modes**: `permissive` (default) falls back to runc; `strict` fails if gVisor unavailable
+- **Security modes**: `strict` (default) fails closed if gVisor is unavailable; `permissive` falls back to runc (dev/CI only)
 - **ExecutionRecord** status: `queued`, `running`, `succeeded`, `failed`, `timeout`, `oom`, `cancelled`
 - **Queue job** status: `pending`, `running`, `completed` (different from ExecutionRecord)
 - **Timeouts**: `startup_timeout` (dep install) vs `timeout` (code execution), configured separately

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ tako-vm --config my.yaml server   # Use specific config file
 
 Tako VM runs untrusted, often AI-generated, code, so isolation is the core of the project. It uses layered defenses: gVisor (userspace kernel), per-job ephemeral Docker containers, a default-deny seccomp profile, network isolation (`--network=none` by default), capability dropping, non-root execution, and enforced resource and input limits.
 
-For untrusted workloads in production, set `security_mode: strict` with `container_runtime: runsc`. The default `permissive` mode falls back to standard Docker (`runc`) if gVisor is unavailable, which removes the userspace-kernel boundary.
+`security_mode: strict` with `container_runtime: runsc` is the default: Tako VM refuses to start a job rather than run it without the gVisor userspace-kernel boundary. Set `security_mode: permissive` to allow a fallback to standard Docker (`runc`) on hosts without gVisor, e.g. local development or CI; that fallback removes the userspace-kernel boundary, so do not use it for untrusted code.
 
 See [SECURITY.md](SECURITY.md) for the threat model and hardening guidance, and [docs/deployment/security.md](docs/deployment/security.md) for full details.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -103,7 +103,7 @@ For stronger isolation than gVisor provides, run Tako VM on dedicated hosts or p
 
 Several defaults in the shipped example configuration favor ease of first-run over maximum hardening. If you are exposing Tako VM to untrusted code in production, do not run with the example defaults unchanged. At minimum:
 
-- Set `security_mode: strict`. The default is `permissive`, which silently falls back to standard `runc` if gVisor is unavailable, meaning untrusted code can end up running without the userspace-kernel boundary you expect. `strict` fails closed instead.
+- Keep `security_mode: strict` (the default). It fails closed if gVisor is unavailable. `permissive` silently falls back to standard `runc`, meaning untrusted code can end up running without the userspace-kernel boundary you expect.
 - Install and verify gVisor (`docker run --runtime=runsc --rm hello-world`) and keep `container_runtime: runsc`.
 - Keep `enable_seccomp: true`.
 - Terminate TLS in front of the API and keep rate limiting enabled.
@@ -112,4 +112,6 @@ Several defaults in the shipped example configuration favor ease of first-run ov
 - Keep the host kernel, Docker, and gVisor patched.
 - Review execution records and logs, and re-test your isolation controls after upgrades, since security-relevant defaults can change.
 
-A deployment that leaves `security_mode: permissive` on a host without gVisor is running untrusted code with only standard container isolation. Treat that as an unsafe configuration for AI-generated or otherwise untrusted input.
+A deployment that sets `security_mode: permissive` on a host without gVisor is running untrusted code with only standard container isolation. Treat that as an unsafe configuration for AI-generated or otherwise untrusted input.
+
+The server binds `127.0.0.1` by default. Binding a non-loopback interface while `api_auth_enabled` is false is refused at startup, because that combination is an unauthenticated remote code-execution endpoint; `allow_unauthenticated_network_access: true` overrides it for deployments that authenticate in front of Tako VM.

--- a/docs/deployment/security.md
+++ b/docs/deployment/security.md
@@ -345,7 +345,7 @@ For higher security, consider:
 
 ## gVisor Runtime
 
-Tako VM supports gVisor (runsc) for strong container isolation. gVisor provides a userspace kernel that intercepts and emulates syscalls, adding a significant security boundary beyond standard Docker. By default, Tako VM runs in `permissive` mode, which falls back to runc if gVisor is not installed.
+Tako VM supports gVisor (runsc) for strong container isolation. gVisor provides a userspace kernel that intercepts and emulates syscalls, adding a significant security boundary beyond standard Docker. By default, Tako VM runs in `strict` mode, which refuses to run a job at all if gVisor is not installed, rather than silently falling back to runc.
 
 ### Why gVisor?
 
@@ -384,7 +384,7 @@ security_mode: strict      # 'strict' (require gVisor) or 'permissive' (fallback
 
 **Security modes:**
 
-- **permissive** (default): Falls back to standard runc runtime with a warning. Works on all platforms.
+- **permissive**: Falls back to standard runc runtime with a warning. Works on all platforms. Development and CI only.
 - **strict**: Fails with `RuntimeUnavailableError` if gVisor is not available. Recommended for production.
 
 **Environment variable override (useful for testing):**
@@ -423,7 +423,7 @@ The Lima VM provides:
 | Kernel exploits | Protected | Vulnerable |
 | Setup complexity | Requires installation | Built into Docker |
 
-**Recommendation:** Use gVisor (`strict` mode) for production and any environment running untrusted or AI-generated code. Use `permissive` mode only for development when gVisor is not available.
+**Recommendation:** Keep the `strict` default for production and any environment running untrusted or AI-generated code. Use `permissive` mode only for development when gVisor is not available.
 
 ## Docker Isolation Limitations
 

--- a/tako_vm.yaml.example
+++ b/tako_vm.yaml.example
@@ -13,7 +13,9 @@ production_mode: false
 # Server
 # =============================================================================
 
-server_host: "0.0.0.0"
+# Loopback by default. Binding a non-loopback host with api_auth_enabled=false
+# is REFUSED at startup (see allow_unauthenticated_network_access).
+server_host: "127.0.0.1"
 server_port: 8000
 log_level: INFO  # DEBUG, INFO, WARNING, ERROR, CRITICAL
 
@@ -66,9 +68,10 @@ enable_userns: false   # Run as non-root user (disable if using gosu)
 container_runtime: runsc
 
 # Security mode:
-# - 'permissive' (default): Falls back to runc if gVisor is unavailable.
+# - 'permissive': Falls back to runc if gVisor is unavailable. Dev/CI only.
 # - 'strict': Fails if gVisor is unavailable. Use this for production.
-security_mode: permissive
+# 'strict' (default) fails closed when gVisor is unavailable.
+security_mode: strict
 
 # =============================================================================
 # Container Resource Limits

--- a/tako_vm/config.py
+++ b/tako_vm/config.py
@@ -260,10 +260,21 @@ class TakoVMConfig(BaseModel):
 
     # Server
     server_host: str = Field(
-        default="0.0.0.0",
+        default="127.0.0.1",
         description=(
-            "Server host to bind to. The default (0.0.0.0, all interfaces) is "
-            "development-friendly; production should bind to a loopback or internal interface"
+            "Server host to bind to. Defaults to loopback: the API executes arbitrary code and "
+            "ships with authentication disabled, so binding all interfaces by default would "
+            "expose an unauthenticated code-execution endpoint to the network. Set 0.0.0.0 "
+            "only together with api_auth_enabled (see allow_unauthenticated_network_access)"
+        ),
+    )
+    allow_unauthenticated_network_access: bool = Field(
+        default=False,
+        description=(
+            "Escape hatch: permit binding a non-loopback interface while api_auth_enabled is "
+            "false. Refused by default, because that combination is an unauthenticated remote "
+            "code-execution endpoint. Only set this when something else (a private network, a "
+            "service mesh, an authenticating reverse proxy) provides the access control"
         ),
     )
     server_port: int = Field(default=8000, ge=1, le=65535, description="Server port to bind to")
@@ -352,11 +363,39 @@ class TakoVMConfig(BaseModel):
             normalized.append(key)
         return normalized
 
+    def is_loopback_host(self) -> bool:
+        """Whether server_host binds only the loopback interface.
+
+        Single source of truth for the check, shared by the fail-closed
+        validator and ``security_warnings`` so the two can never disagree
+        about what counts as network-exposed.
+        """
+        host = self.server_host.strip().lower()
+        return host in _LOOPBACK_HOSTS or host.startswith("127.")
+
     @model_validator(mode="after")
     def validate_api_auth_config(self) -> "TakoVMConfig":
-        """Require at least one API key when auth is enabled."""
+        """Require a key when auth is on, and refuse unauthenticated network exposure."""
         if self.api_auth_enabled and not self.api_keys:
             raise ValueError("api_keys must contain at least one key when api_auth_enabled=true")
+
+        # Fail closed on the one combination that is an unauthenticated remote
+        # code-execution endpoint. This used to be a startup log line, which is
+        # the wrong control for it: a warning scrolls past, and the operator who
+        # most needs it is the one who never reads the log. An explicit opt-out
+        # keeps it possible for deployments that authenticate elsewhere.
+        if (
+            not self.api_auth_enabled
+            and not self.is_loopback_host()
+            and not self.allow_unauthenticated_network_access
+        ):
+            raise ValueError(
+                f"refusing to bind non-loopback host '{self.server_host}' with "
+                "api_auth_enabled=false: this exposes an unauthenticated code-execution "
+                "endpoint to the network. Enable api_auth_enabled and set api_keys, bind "
+                "server_host to 127.0.0.1, or set allow_unauthenticated_network_access=true "
+                "if access control is enforced outside Tako VM"
+            )
         return self
 
     database_url: str = Field(
@@ -488,11 +527,13 @@ class TakoVMConfig(BaseModel):
 
     # Security mode
     security_mode: str = Field(
-        default="permissive",
+        default="strict",
         description=(
-            "Security mode: 'strict' fails if gVisor unavailable, 'permissive' allows fallback "
-            "to runc. The default (permissive) is development-friendly; production should use "
-            "'strict'"
+            "Security mode: 'strict' (default) FAILS if gVisor is unavailable rather than "
+            "running untrusted code behind a weaker boundary; 'permissive' allows a silent "
+            "fallback to runc. gVisor is the isolation boundary this project promises, so the "
+            "default fails closed. Set 'permissive' only when you accept runc-level isolation "
+            "(e.g. local development or CI on a host without gVisor)"
         ),
     )
 
@@ -631,14 +672,14 @@ class TakoVMConfig(BaseModel):
         """
         warnings: List[str] = []
 
-        host = self.server_host.strip().lower()
-        is_loopback = host in _LOOPBACK_HOSTS or host.startswith("127.")
-        if not self.api_auth_enabled and not is_loopback:
+        if not self.api_auth_enabled and not self.is_loopback_host():
+            # Reachable only via allow_unauthenticated_network_access; the
+            # validator refuses this combination otherwise.
             warnings.append(
                 f"API authentication is disabled (api_auth_enabled=false) while the server "
-                f"binds to non-loopback host '{self.server_host}': anyone who can reach the "
-                "port can execute code. Enable api_auth_enabled and set api_keys, or bind "
-                "server_host to 127.0.0.1."
+                f"binds to non-loopback host '{self.server_host}', permitted only because "
+                "allow_unauthenticated_network_access=true: anyone who can reach the port can "
+                "execute code. Ensure access control is enforced in front of Tako VM."
             )
 
         if self.security_mode == "permissive":

--- a/tako_vm/constants.py
+++ b/tako_vm/constants.py
@@ -11,8 +11,39 @@ import tempfile
 # Docker image for code execution
 DEFAULT_IMAGE = "code-executor:latest"
 
-# Docker volume name for uv cache (speeds up repeated dependency installs)
+# Base name for the uv cache volume (speeds up repeated dependency installs).
+# Never mounted directly: use uv_cache_volume() so the volume is scoped.
 UV_CACHE_VOLUME = "tako-uv-cache"
+
+# Characters allowed in the scope suffix of a cache volume name. Job type names
+# are already validated to alphanumerics/dash/underscore, so this is a
+# belt-and-braces guard against a scope reaching the docker CLI unsanitized.
+_SAFE_SCOPE_CHARS = frozenset("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_")
+
+
+def uv_cache_volume(scope: str) -> str:
+    """Return the uv cache volume name for a given sharing scope.
+
+    The shared dependency cache is a cross-job channel: it is mounted
+    read-write at a path the sandbox user owns, and it stays mounted for the
+    container's whole life, not just the install phase. So one job can write a
+    cache entry that a later job's ``uv pip install`` resolves and executes.
+
+    A single host-wide volume made that boundary "every job on this host".
+    Scoping the volume per job type narrows it to a group the OPERATOR defines:
+    jobs of different types can no longer reach each other's cache.
+
+    This reduces blast radius, it does not eliminate the channel. Jobs sharing
+    one job type still share one cache, so if you accept untrusted submissions
+    into a job type that has ``allow_runtime_requirements`` AND
+    ``enable_runtime_dependency_cache`` enabled, they can still poison each
+    other. Tako VM has no tenant identity to key on; job type is the only
+    boundary it knows. Give mutually untrusting workloads distinct job types,
+    or leave the cache disabled (the default).
+    """
+    sanitized = "".join(c if c in _SAFE_SCOPE_CHARS else "-" for c in scope) or "default"
+    return f"{UV_CACHE_VOLUME}-{sanitized[:64]}"
+
 
 # In-container uv cache locations. The shared-volume mount point lives under the
 # sandbox user's home (uid 1000), deliberately NOT under /root: the dependency

--- a/tako_vm/execution/docker.py
+++ b/tako_vm/execution/docker.py
@@ -6,6 +6,7 @@ Shared utilities for Docker operations across worker and sandbox.
 
 import json
 import logging
+import os
 import platform
 import subprocess
 import time
@@ -571,6 +572,93 @@ def base_isolation_args(
     return args
 
 
+# Host paths a session workspace may never resolve to or sit directly under.
+# A bind mount of any of these hands the container the host's identity,
+# secrets, or the docker socket (which is a trivial full escape).
+_FORBIDDEN_WORKSPACE_ROOTS = (
+    "/",
+    "/etc",
+    "/root",
+    "/home",
+    "/boot",
+    "/dev",
+    "/proc",
+    "/sys",
+    "/var/run",
+    "/run",
+    "/usr",
+    "/bin",
+    "/sbin",
+    "/lib",
+    "/var/lib/docker",
+)
+
+
+def validate_session_workspace_dir(workspace_dir: str) -> str:
+    """Validate a session workspace path before it becomes a host bind mount.
+
+    ``build_session_run_command`` mounts this read-write at ``/workspace``, so
+    an unvalidated value is a host-filesystem escape: ``..`` traversal out of
+    the sessions root, an absolute path to ``/``, or a symlink pointing at
+    ``/etc`` all turn the session workspace into arbitrary host access. This is
+    the same shape as the snapshot-id path traversal found in comparable
+    products, caught before the code path is reachable.
+
+    Enforced:
+
+    - non-empty, no NUL or newline (which would also break the docker argv),
+    - absolute and fully normalized (rejects ``..`` and ``.`` components),
+    - not a bare sensitive system directory, and not the filesystem root,
+    - if it exists, its REAL path (symlinks resolved) must still satisfy the
+      above, so a symlinked workspace cannot redirect the mount.
+
+    Returns:
+        The normalized path, safe to place in a ``-v`` argument.
+
+    Raises:
+        ValueError: the path is unsafe. Callers should treat this as a refusal
+            to start the session, never as something to sanitize and retry.
+    """
+    if not workspace_dir or not workspace_dir.strip():
+        raise ValueError("session workspace_dir must not be empty")
+    if any(ch in workspace_dir for ch in ("\x00", "\n", "\r")):
+        raise ValueError("session workspace_dir must not contain control characters")
+
+    candidate = Path(workspace_dir)
+    if not candidate.is_absolute():
+        raise ValueError(f"session workspace_dir must be an absolute path: {workspace_dir!r}")
+
+    # os.path.normpath collapses '..' textually; comparing against the input
+    # rejects any path that was not already normalized, rather than silently
+    # "fixing" a traversal attempt into something that looks safe.
+    normalized = Path(os.path.normpath(str(candidate)))
+    if str(normalized) != str(candidate).rstrip("/") or ".." in candidate.parts:
+        raise ValueError(
+            f"session workspace_dir must be normalized and contain no '..': {workspace_dir!r}"
+        )
+
+    def _reject_if_sensitive(path: Path, why: str) -> None:
+        as_str = str(path)
+        if as_str in _FORBIDDEN_WORKSPACE_ROOTS:
+            raise ValueError(f"session workspace_dir {why} a sensitive host directory: {as_str!r}")
+        for root in _FORBIDDEN_WORKSPACE_ROOTS:
+            if root != "/" and as_str.startswith(root + "/") and as_str.count("/") <= 2:
+                raise ValueError(
+                    f"session workspace_dir {why} directly under a sensitive host "
+                    f"directory: {as_str!r}"
+                )
+
+    _reject_if_sensitive(normalized, "is")
+
+    # Resolve symlinks when the path exists: a workspace dir that is itself a
+    # symlink to /etc would otherwise pass every textual check above.
+    if normalized.exists():
+        real = normalized.resolve()
+        _reject_if_sensitive(real, "resolves to")
+
+    return str(normalized)
+
+
 def build_session_run_command(
     container_name: str,
     *,
@@ -625,6 +713,15 @@ def build_session_run_command(
     Returns:
         The full ``docker run`` argument list, ready to execute.
     """
+    # The workspace path becomes a read-write host bind mount, so it is the
+    # highest-value injection target in this builder: a caller-influenced
+    # session id or name that reaches it unchecked turns "mount the session's
+    # workspace" into "mount any host directory read-write into a container".
+    # Validated here, at the point of use, so no caller can forget -- this
+    # builder is not wired into a live path yet, and the guard must exist
+    # BEFORE it is.
+    workspace_dir = validate_session_workspace_dir(workspace_dir)
+
     cmd = base_isolation_args(
         container_name,
         runtime=runtime,

--- a/tako_vm/execution/worker.py
+++ b/tako_vm/execution/worker.py
@@ -20,9 +20,9 @@ from tako_vm.config import TakoVMConfig, get_config
 from tako_vm.constants import (
     MAX_REQUIREMENTS,
     UV_CACHE_TMP_DIR,
-    UV_CACHE_VOLUME,
     UV_CACHE_VOLUME_DIR,
     get_workspace_dir,
+    uv_cache_volume,
 )
 from tako_vm.execution.docker import (
     EXECUTOR_ENTRYPOINT,
@@ -1391,7 +1391,11 @@ class CodeExecutor:
             uv_cache_dir = UV_CACHE_TMP_DIR
             if self.config.enable_runtime_dependency_cache:
                 uv_cache_dir = UV_CACHE_VOLUME_DIR
-                cmd.append(f"--mount=type=volume,source={UV_CACHE_VOLUME},target={uv_cache_dir}")
+                # Scoped per job type, not one host-wide volume: the cache is a
+                # writable cross-job channel that outlives the install phase.
+                # See uv_cache_volume() for what this does and does not fix.
+                cache_volume = uv_cache_volume(job_type.name)
+                cmd.append(f"--mount=type=volume,source={cache_volume},target={uv_cache_dir}")
             cmd.append(f"--env=UV_CACHE_DIR={uv_cache_dir}")
 
         # Network isolation (default: no network for security)

--- a/tako_vm/sandbox.py
+++ b/tako_vm/sandbox.py
@@ -29,9 +29,9 @@ from tako_vm.constants import (
     DEFAULT_IMAGE,
     MAX_REQUIREMENTS,
     UV_CACHE_TMP_DIR,
-    UV_CACHE_VOLUME,
     UV_CACHE_VOLUME_DIR,
     get_workspace_dir,
+    uv_cache_volume,
 )
 from tako_vm.execution import resolve_runtime
 from tako_vm.execution.docker import (
@@ -148,6 +148,12 @@ class SandboxConfig:
 
     enable_cap_restrictions: bool = field(default_factory=_default_enable_cap_restrictions)
     """Enable capability restrictions (--cap-drop=ALL --cap-add=...)."""
+
+    cache_scope: str = "default"
+    """Sharing scope for the runtime dependency cache volume.
+
+    Mirrors the server path's per-job-type scoping. Sandboxes given different
+    scopes cannot reach each other's uv cache; see ``uv_cache_volume``."""
 
 
 class Sandbox:
@@ -596,7 +602,11 @@ class Sandbox:
             uv_cache_dir = UV_CACHE_TMP_DIR
             if self.config.enable_runtime_dependency_cache:
                 uv_cache_dir = UV_CACHE_VOLUME_DIR
-                cmd.append(f"--mount=type=volume,source={UV_CACHE_VOLUME},target={uv_cache_dir}")
+                # Scoped like the server path (see uv_cache_volume). Library
+                # mode has no job type, so the scope is caller-supplied and
+                # defaults to "default".
+                cache_volume = uv_cache_volume(self.config.cache_scope)
+                cmd.append(f"--mount=type=volume,source={cache_volume},target={uv_cache_dir}")
             cmd.append(f"--env=UV_CACHE_DIR={uv_cache_dir}")
 
         # Resource limits. The pids-limit and the --ulimit set (nofile/nproc/

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -257,7 +257,12 @@ class TestTakoVMConfig:
         assert config.max_workers == 4
         assert config.default_timeout == 30
         assert config.container_runtime == "runsc"
-        assert config.security_mode == "permissive"
+        # Secure by default: fail closed rather than silently fall back to runc.
+        assert config.security_mode == "strict"
+        # Loopback by default: the API executes arbitrary code and ships with
+        # auth disabled, so it must not be network-reachable out of the box.
+        assert config.server_host == "127.0.0.1"
+        assert config.allow_unauthenticated_network_access is False
         assert config.api_max_payload_bytes == 2097152
         assert config.api_rate_limit_enabled is True
         assert config.api_rate_limit_requests == 120
@@ -383,12 +388,24 @@ class TestSecurityWarnings:
     """Tests for TakoVMConfig.security_warnings()."""
 
     def test_security_warnings_default_config(self):
-        """Default config warns about disabled auth and permissive mode."""
-        warnings = TakoVMConfig().security_warnings()
+        """The defaults are secure, so they produce no warnings at all.
 
-        assert len(warnings) == 2
+        Previously the defaults were permissive + 0.0.0.0 and emitted two
+        warnings. Warnings were the wrong control for those: the defaults now
+        fail closed instead (strict mode, loopback bind), so a clean default
+        deployment has nothing to warn about.
+        """
+        assert TakoVMConfig().security_warnings() == []
+
+    def test_security_warnings_when_unauthenticated_bind_is_opted_into(self):
+        """The escape hatch still has to be loud."""
+        config = TakoVMConfig(
+            server_host="0.0.0.0",
+            api_auth_enabled=False,
+            allow_unauthenticated_network_access=True,
+        )
+        warnings = config.security_warnings()
         assert any("api_auth_enabled" in w for w in warnings)
-        assert any("permissive" in w for w in warnings)
 
     def test_security_warnings_empty_for_locked_down_config(self):
         """Auth enabled + strict mode produces no warnings."""
@@ -419,8 +436,14 @@ class TestSecurityWarnings:
         assert len(warnings) == 1
         assert "permissive" in warnings[0]
 
-    def test_load_config_logs_security_warnings(self, caplog):
-        """load_config emits security warnings via logging."""
+    def test_load_config_logs_security_warnings(self, caplog, monkeypatch):
+        """load_config emits security warnings via logging.
+
+        Driven from an explicitly weakened config: the defaults are secure now,
+        so they emit nothing, and asserting on a default load would test that
+        the logging path is dead rather than that it works.
+        """
+        monkeypatch.setenv("TAKO_VM_SECURITY_MODE", "permissive")
         with caplog.at_level(logging.WARNING, logger="tako_vm.config"):
             load_config()
 

--- a/tests/test_default_posture.py
+++ b/tests/test_default_posture.py
@@ -25,7 +25,7 @@ import pytest
 
 from tako_vm.sandbox import Sandbox
 
-from .conftest import requires_docker, requires_executor_image
+from .conftest import GVISOR_AVAILABLE, requires_docker, requires_executor_image
 
 # Probes the two controls that were silently absent on the library path.
 PROBE = textwrap.dedent(
@@ -62,9 +62,20 @@ class TestShippedDefaultsRunCode:
         from tako_vm import config as config_mod
         from tako_vm.config import TakoVMConfig
 
-        cfg = TakoVMConfig(data_dir=str(request.config.invocation_params.dir / ".tako-probe"))
+        # Everything at its shipped default EXCEPT the runtime gate:
+        # security_mode defaults to strict, which correctly refuses to run at
+        # all on a host without gVisor (every GitHub runner). The controls
+        # under test here -- seccomp and the capability set -- are
+        # runtime-independent, so relax only that one field when the host
+        # cannot provide gVisor, and leave it at the real default when it can.
+        cfg = TakoVMConfig(
+            data_dir=str(request.config.invocation_params.dir / ".tako-probe"),
+            **({} if GVISOR_AVAILABLE else {"security_mode": "permissive"}),
+        )
         cfg.resolve_paths()
         assert cfg.enable_seccomp and cfg.enable_cap_restrictions
+        if GVISOR_AVAILABLE:
+            assert cfg.security_mode == "strict"
         original = config_mod._config
         config_mod._config = cfg
         os.environ.pop("TAKO_VM_ENABLE_CAP_RESTRICTIONS", None)

--- a/tests/test_isolation_invariants.py
+++ b/tests/test_isolation_invariants.py
@@ -18,13 +18,17 @@ and can gate every PR.
 """
 
 import pytest
+from pydantic import ValidationError
 
 from tako_vm.config import TakoVMConfig
+from tako_vm.constants import UV_CACHE_VOLUME, uv_cache_volume
 from tako_vm.execution import worker
 from tako_vm.execution.docker import (
     CONTAINER_LABEL,
     EXECUTION_ID_LABEL,
     base_isolation_args,
+    build_session_run_command,
+    validate_session_workspace_dir,
 )
 from tako_vm.execution.worker import RuntimeUnavailableError, resolve_runtime
 
@@ -466,4 +470,127 @@ class TestSeccompProfileStartsContainers:
             assert len(eq_on_zero) <= 1, (
                 "prctl rule lists multiple values in one rule; args are AND-ed, "
                 f"so this rule matches nothing: {rule}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Secure-by-default configuration
+#
+# The defaults are what a scanner reads and what a new user gets. These pin the
+# three that decide whether the advertised boundary is actually in force.
+# ---------------------------------------------------------------------------
+
+
+class TestSecureDefaults:
+    def test_security_mode_defaults_to_strict(self):
+        """Fail closed: no silent runc fallback unless explicitly asked for."""
+        assert TakoVMConfig().security_mode == "strict"
+
+    def test_container_runtime_defaults_to_gvisor(self):
+        assert TakoVMConfig().container_runtime == "runsc"
+
+    def test_server_binds_loopback_by_default(self):
+        assert TakoVMConfig().is_loopback_host()
+
+    def test_seccomp_and_caps_on_by_default(self):
+        cfg = TakoVMConfig()
+        assert cfg.enable_seccomp
+        assert cfg.enable_cap_restrictions
+
+    def test_runtime_deps_and_shared_cache_off_by_default(self):
+        cfg = TakoVMConfig()
+        assert not cfg.allow_runtime_requirements
+        assert not cfg.enable_runtime_dependency_cache
+
+    def test_unauthenticated_network_bind_is_refused(self):
+        """The one combination that is unauthenticated remote code execution."""
+        with pytest.raises(ValidationError):
+            TakoVMConfig(server_host="0.0.0.0", api_auth_enabled=False)
+
+    def test_unauthenticated_loopback_bind_is_allowed(self):
+        """Local development stays frictionless."""
+        assert TakoVMConfig(server_host="127.0.0.1", api_auth_enabled=False)
+
+    def test_authenticated_network_bind_is_allowed(self):
+        assert TakoVMConfig(server_host="0.0.0.0", api_auth_enabled=True, api_keys=["k" * 32])
+
+    def test_explicit_opt_out_permits_unauthenticated_bind(self):
+        cfg = TakoVMConfig(
+            server_host="0.0.0.0",
+            api_auth_enabled=False,
+            allow_unauthenticated_network_access=True,
+        )
+        # ...but it must still be surfaced loudly.
+        assert any("authentication is disabled" in w for w in cfg.security_warnings())
+
+
+class TestDependencyCacheScoping:
+    """The shared uv cache is a writable cross-job channel; scope it."""
+
+    def test_distinct_scopes_get_distinct_volumes(self):
+        assert uv_cache_volume("alpha") != uv_cache_volume("beta")
+
+    def test_same_scope_is_stable(self):
+        assert uv_cache_volume("alpha") == uv_cache_volume("alpha")
+
+    def test_scope_is_sanitized_for_the_docker_cli(self):
+        volume = uv_cache_volume("../../etc/passwd; rm -rf /")
+        assert "/" not in volume and ";" not in volume and " " not in volume
+
+    def test_empty_scope_does_not_produce_a_bare_shared_volume(self):
+        assert uv_cache_volume("") != UV_CACHE_VOLUME
+
+
+class TestSessionWorkspaceContainment:
+    """``workspace_dir`` becomes a read-write host bind mount."""
+
+    @pytest.mark.parametrize(
+        "bad",
+        [
+            "",
+            "   ",
+            "relative/path",
+            "/srv/sessions/../../etc",
+            "/",
+            "/etc",
+            "/root",
+            "/var/run",
+            "/var/lib/docker",
+            "/etc/ssh",
+            "/tmp/ws\x00/etc",
+            "/tmp/ws\nmalicious",
+        ],
+    )
+    def test_unsafe_workspace_dirs_are_refused(self, bad):
+        with pytest.raises(ValueError):
+            validate_session_workspace_dir(bad)
+
+    def test_ordinary_workspace_dir_is_accepted(self):
+        assert validate_session_workspace_dir("/srv/sessions/sess-abc/workspace") == (
+            "/srv/sessions/sess-abc/workspace"
+        )
+
+    def test_bare_dot_components_are_normalized_not_rejected(self):
+        """'.' is a no-op component with no traversal consequence.
+
+        pathlib collapses it at construction, so it never reaches the mount as
+        written. Only '..' can escape, and that is refused above.
+        """
+        assert validate_session_workspace_dir("/srv/sessions/./x") == "/srv/sessions/x"
+
+    def test_symlinked_workspace_cannot_redirect_the_mount(self, tmp_path):
+        link = tmp_path / "workspace"
+        link.symlink_to("/etc")
+        with pytest.raises(ValueError):
+            validate_session_workspace_dir(str(link))
+
+    def test_builder_refuses_to_emit_an_unsafe_mount(self):
+        """The guard must be enforced at the point of use, not just available."""
+        with pytest.raises(ValueError):
+            build_session_run_command(
+                "tako-session-x",
+                runtime="runsc",
+                image="code-executor:latest",
+                workspace_dir="/srv/sessions/../../../etc",
+                session_id="sess-x",
             )

--- a/tests/test_sandbox.py
+++ b/tests/test_sandbox.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import pytest
 
-from tako_vm.constants import UV_CACHE_TMP_DIR, UV_CACHE_VOLUME, UV_CACHE_VOLUME_DIR
+from tako_vm.constants import UV_CACHE_TMP_DIR, UV_CACHE_VOLUME_DIR, uv_cache_volume
 from tako_vm.sandbox import DEFAULT_STARTUP_TIMEOUT, Sandbox, SandboxResult
 from tako_vm.sandbox import run as sandbox_run
 
@@ -398,7 +398,10 @@ print(f"version: {requests.__version__}")
             requirements=["requests"],
         )
 
-        cache_mount = f"--mount=type=volume,source={UV_CACHE_VOLUME},target={UV_CACHE_VOLUME_DIR}"
+        # Volume is scoped (see uv_cache_volume): the library path uses the
+        # SandboxConfig.cache_scope, which defaults to "default".
+        cache_volume = uv_cache_volume("default")
+        cache_mount = f"--mount=type=volume,source={cache_volume},target={UV_CACHE_VOLUME_DIR}"
         expected_cache_dir = UV_CACHE_VOLUME_DIR if cache_enabled else UV_CACHE_TMP_DIR
         assert (cache_mount in cmd) is expect_cache_mount
         assert f"--env=UV_CACHE_DIR={expected_cache_dir}" in cmd

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -6,7 +6,7 @@ import pytest
 
 import tako_vm.execution.worker as worker_module
 from tako_vm.config import TakoVMConfig
-from tako_vm.constants import UV_CACHE_TMP_DIR, UV_CACHE_VOLUME, UV_CACHE_VOLUME_DIR
+from tako_vm.constants import UV_CACHE_TMP_DIR, UV_CACHE_VOLUME_DIR, uv_cache_volume
 from tako_vm.execution import CodeExecutor
 from tako_vm.job_types import JobType
 from tako_vm.security import (
@@ -419,7 +419,10 @@ class TestExecutorRejectsUnsafeIds:
             job_id="job-123",
         )
 
-        cache_mount = f"--mount=type=volume,source={UV_CACHE_VOLUME},target={UV_CACHE_VOLUME_DIR}"
+        # Volume is scoped per job type (see uv_cache_volume); this job type
+        # is named "default".
+        cache_volume = uv_cache_volume("default")
+        cache_mount = f"--mount=type=volume,source={cache_volume},target={UV_CACHE_VOLUME_DIR}"
         expected_cache_dir = UV_CACHE_VOLUME_DIR if cache_enabled else UV_CACHE_TMP_DIR
         assert result["success"] is True
         assert (cache_mount in captured["cmd"]) is expect_cache_mount


### PR DESCRIPTION
Follow-up to #153. Those were controls that **did not work**. These are defaults and boundaries that worked exactly as written, but where what was written was the permissive choice — and a scanner reads the default, not the warning next to it.

## 1. `security_mode` now defaults to `strict`

It was `permissive`, so on any host without gVisor every job silently ran on `runc` while `CLAUDE.md` says *"gVisor remains the sole isolation boundary"*. Strict refuses to run instead. Set `permissive` explicitly for local dev and CI on hosts without gVisor.

## 2. Loopback by default, and unauthenticated network bind is refused

`server_host` now defaults to `127.0.0.1`, and binding a non-loopback interface while `api_auth_enabled` is false is **refused at startup** rather than warned about. That combination is an unauthenticated remote code-execution endpoint; a log line is the wrong control for it, because the operator who most needs it is the one not reading logs.

`allow_unauthenticated_network_access: true` is the explicit opt-out for deployments that authenticate in front of Tako VM — and it still emits the warning.

## 3. Dependency cache scoped per job type

The shared uv cache is mounted read-write at a path the sandbox user owns, and it stays mounted for the container's **whole life**, not just the install phase. So one job can write a cache entry that a later job's `uv pip install` resolves and executes. It was a single host-wide volume.

Now scoped per job type. **This narrows the blast radius to a group the operator defines; it does not eliminate the channel** — jobs sharing a job type still share a cache. Tako VM has no tenant identity to key on, and inventing one here would be the wrong call. Documented honestly in `uv_cache_volume()`.

## 4. Session workspace containment, added before the path is reachable

`build_session_run_command` puts `workspace_dir` straight into `-v {dir}:/workspace`, and `SessionRecord.workspace_dir` validated length only. Now validated at the point of use: absolute, normalized, no `..`, not a sensitive system directory, and symlink-resolved so a symlinked workspace cannot redirect the mount.

Nothing calls this yet (Phase 1a scaffolding). The guard goes in while the path is still unreachable, rather than after.

## Tests

Each item has coverage: the secure defaults; that the unauthenticated network bind is refused while loopback / authenticated / explicitly-opted-out all still work; that cache scopes are distinct and shell-safe; and a table of unsafe workspace paths including a symlink redirect.

Existing tests that asserted the old defaults are updated to assert the **new intent**, not the new strings. `test_default_posture` relaxes only `security_mode` when the host has no gVisor, since seccomp and capabilities are runtime-independent.

## Verification

gVisor was installed on the audit host for this (it was the gap flagged in #153):

- **802 passed** under `strict` + `runsc`.
- **798 passed** with `runsc` removed to simulate a CI runner; the remaining failures were this box's known load-related container stalls, which reproduce on `origin/main` and did not recur after freeing disk (the host sits at 92% full).

Also worth recording from that exercise: of the four defects in #153, the seccomp-blocks-init one was **runc-specific** — runsc runs its own container init and never tripped the filter. The entrypoint `chown` abort and the CAP_KILL timeout failure reproduced **identically under gVisor**, i.e. they broke the recommended production boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HCi216irm5J9XxAW14WGPh
