### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,17 @@ All notable changes to Tako VM are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.0] - 2026-09-02
+
+A security release, and the one that closes the hole the quickstart itself
+published: `docker compose up` served an unauthenticated `POST /execute` on
+every interface, plus PostgreSQL on `5432` with `postgres`/`postgres`. Anyone
+who followed the README was running remote code execution open to their
+network. Upgrade before anything else.
+
+The minor bump is the `max_timeout` ceiling below, not the security fixes: a
+deployment whose `job_types` declare a timeout above `max_timeout` is now
+refused at startup instead of quietly exceeding its own limit.
 
 ### Security
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "tako-vm"
-version = "0.2.0"
+version = "0.3.0"
 description = "A secure file system and Python execution layer for AI agents: isolated Docker/gVisor containers with job queues, retries, and history"
 readme = "README.md"
 license = "Apache-2.0"


### PR DESCRIPTION
PyPI and GHCR still serve 0.2.0 — the build whose own quickstart publishes an unauthenticated `POST /execute` on every interface and PostgreSQL on 5432 with `postgres`/`postgres`. #160 fixed that on main; nobody following the README has received it, and `docker compose up` is the documented first step.

Minor rather than patch because `[Unreleased]` already carried a BREAKING entry: #146 enforces `max_timeout` on the *effective* timeout, so a deployment whose `job_types` declare a larger default is now refused at startup instead of quietly exceeding its own ceiling. Calling that a patch would let it arrive unannounced.

`[Unreleased]` becomes `[0.3.0] - 2026-09-02` with a lede naming the defect to upgrade for; `pyproject.toml` follows. No code changes — everything in this release is already on main and tested there. Tagging `v0.3.0` on the merge commit publishes to PyPI, GHCR and Releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BcaZW5HwWhhyP7Y17bA6oh