### PR TITLE
Raise docs dependency floors past four known CVEs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,7 +26,9 @@ jobs:
           sudo apt-get install -y libcairo2-dev libfreetype6-dev libffi-dev libjpeg-dev libpng-dev libz-dev pngquant
 
       - name: Install dependencies
-        run: pip install "mkdocs-material[imaging]" mkdocs-git-revision-date-localized-plugin
+        # Floors match the docs extra in pyproject.toml. This workflow resolves at
+        # build time rather than from uv.lock, so the pins have to be repeated here.
+        run: pip install "mkdocs-material[imaging]>=9.7.7" mkdocs-git-revision-date-localized-plugin "GitPython>=3.1.59"
 
       - name: Deploy to GitHub Pages
         run: mkdocs gh-deploy --force

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,8 +70,12 @@ dev = [
 # Documentation
 docs = [
     "mkdocs>=1.5.0",
-    "mkdocs-material[imaging]>=9.0.0",  # [imaging] pulls cairosvg+pillow for social cards
+    # floor 9.7.7: CVE-2026-73295, DOM XSS in the search.suggest feature
+    "mkdocs-material[imaging]>=9.7.7",  # [imaging] pulls cairosvg+pillow for social cards
     "mkdocs-git-revision-date-localized-plugin>=1.2.0",
+    # transitive via the git-revision-date plugin; floor 3.1.59 for
+    # CVE-2026-78675/78676/78677/78678 (arbitrary file read, config injection)
+    "GitPython>=3.1.59",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -285,14 +285,11 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.5.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/fa/656b739db8587d7b5dfa22e22ed02566950fbfbcdc20311993483657a5c0/click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a", size = 295065, upload-time = "2025-11-15T20:45:42.706Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/0e/7fa0ef50764b67090eca4114772a2abf8b6148198475e54c660b97caeee6/click-8.5.0.tar.gz", hash = "sha256:ba0d2089de75ea0310e2dde03160e6ca10009947fb95a182f9b54021bb272e34", size = 382235, upload-time = "2026-08-26T13:33:14.56Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/98/78/01c019cdb5d6498122777c1a43056ebb3ebfeef2076d9d026bfe15583b2b/click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6", size = 108274, upload-time = "2025-11-15T20:45:41.139Z" },
+    { url = "https://files.pythonhosted.org/packages/58/50/6c0d534c5f134586a8e1ba4e330569e32f057e33372ae556463212fb4cd3/click-8.5.0-py3-none-any.whl", hash = "sha256:255bc9599cf7748b4b1a446ccc735421bd08a2ae529a8b88597d3de5664ee360", size = 125251, upload-time = "2026-08-26T13:33:12.928Z" },
 ]
 
 [[package]]
@@ -398,14 +395,14 @@ wheels = [
 
 [[package]]
 name = "gitpython"
-version = "3.1.58"
+version = "3.1.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "gitdb" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/26/d6/5f358ff283325580c2003a6d953aea18cfe10ae87b46f5ebc80fa3a386dc/gitpython-3.1.58.tar.gz", hash = "sha256:621416df10ef3fd0e19fabf9172ddeed0fa704d353d04f194eec56a625a95b22", size = 228498, upload-time = "2026-08-04T15:05:49.47Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/61/3285044215fb596bf093e39ccb96ece0a1076a8ca57a61e069a6a33cdb1b/gitpython-3.1.61.tar.gz", hash = "sha256:f51c24d8c0f733a195447385f5774a5dfe8767f5acfd7994a33755644c6ecc95", size = 231680, upload-time = "2026-08-28T11:01:13.761Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/0c/9d8752098bc442f0726e64aa6135940b3a96809915d1aa4206c1bb97881d/gitpython-3.1.58-py3-none-any.whl", hash = "sha256:d331e722577f0fd7fc1f857419b3ecc07af66282b933d2a4d95f84a042fdd50f", size = 220183, upload-time = "2026-08-04T15:05:48.025Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/5e/49cc172da4d0578644ba37cec5cb365b1fefc603b26edea9bcac1c7f830a/gitpython-3.1.61-py3-none-any.whl", hash = "sha256:8ab28c9da863cdd9e7d7694ec46cf3e6c9a12d8a30a1acd3447aec11975d530c", size = 222118, upload-time = "2026-08-28T11:01:12.262Z" },
 ]
 
 [[package]]
@@ -685,7 +682,7 @@ wheels = [
 
 [[package]]
 name = "mkdocs-material"
-version = "9.7.6"
+version = "9.7.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "babel" },
@@ -700,9 +697,9 @@ dependencies = [
     { name = "pymdown-extensions" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/45/29/6d2bcf41ae40802c4beda2432396fff97b8456fb496371d1bc7aad6512ec/mkdocs_material-9.7.6.tar.gz", hash = "sha256:00bdde50574f776d328b1862fe65daeaf581ec309bd150f7bff345a098c64a69", size = 4097959, upload-time = "2026-03-19T15:41:58.161Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/cd/c05d3a530ba7934f144fb45f7203cd236adc25c7bdcc34673d202f4b0278/mkdocs_material-9.7.7.tar.gz", hash = "sha256:c0649c065b1b0512d60aad8c10f947f8e455284475239b364b610f2deb4d0855", size = 4097923, upload-time = "2026-07-17T16:21:33.156Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2c/01/bc663630c510822c95c47a66af9fa7a443c295b47d5f041e5e6ae62ef659/mkdocs_material-9.7.6-py3-none-any.whl", hash = "sha256:71b84353921b8ea1ba84fe11c50912cc512da8fe0881038fcc9a0761c0e635ba", size = 9305470, upload-time = "2026-03-19T15:41:55.217Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/21/17c1bc9e6f47c972ad66fb2ac2568f99f90f1207eeb6fc3b34d094dba7b5/mkdocs_material-9.7.7-py3-none-any.whl", hash = "sha256:8ea9bb1737a5b524a5f9dcf2e1b4ebda8274ae3008aa7845720a97083bef708f", size = 9305438, upload-time = "2026-07-17T16:21:30.017Z" },
 ]
 
 [package.optional-dependencies]
@@ -1367,7 +1364,7 @@ wheels = [
 
 [[package]]
 name = "tako-vm"
-version = "0.1.5"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "psycopg", extra = ["binary"] },
@@ -1390,6 +1387,7 @@ dev = [
     { name = "ruff" },
 ]
 docs = [
+    { name = "gitpython" },
     { name = "mkdocs" },
     { name = "mkdocs-git-revision-date-localized-plugin" },
     { name = "mkdocs-material", extra = ["imaging"] },
@@ -1409,10 +1407,11 @@ tools = [
 requires-dist = [
     { name = "fastapi", marker = "extra == 'all'", specifier = ">=0.104.0" },
     { name = "fastapi", marker = "extra == 'server'", specifier = ">=0.104.0" },
+    { name = "gitpython", marker = "extra == 'docs'", specifier = ">=3.1.59" },
     { name = "httpx", marker = "extra == 'dev'", specifier = ">=0.24.0" },
     { name = "mkdocs", marker = "extra == 'docs'", specifier = ">=1.5.0" },
     { name = "mkdocs-git-revision-date-localized-plugin", marker = "extra == 'docs'", specifier = ">=1.2.0" },
-    { name = "mkdocs-material", extras = ["imaging"], marker = "extra == 'docs'", specifier = ">=9.0.0" },
+    { name = "mkdocs-material", extras = ["imaging"], marker = "extra == 'docs'", specifier = ">=9.7.7" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2.0" },
     { name = "psycopg-pool", specifier = ">=3.2.0" },
     { name = "pydantic", specifier = ">=2.0.0" },


### PR DESCRIPTION
Found while auditing the open-source dependency trees across the repos. The shipped package is clean — `requests`, `pydantic`, `psycopg`, `pyyaml`, `fastapi`, `uvicorn` scan with zero advisories. Everything below is in the `docs` extra.

## What was vulnerable

| Package | Was | Advisory | Now |
|---|---|---|---|
| `mkdocs-material` | 9.7.6 | **CVE-2026-73295** — DOM XSS in the optional `search.suggest` feature; a crafted `q` URL parameter executes JS in the docs origin after user interaction | 9.7.7 |
| `GitPython` | 3.1.58 | **CVE-2026-78675** arbitrary local file read via `[include]` in `.gitmodules`; **CVE-2026-78676** multi-line config values re-serialize into live directives (`core.hooksPath` injection); **CVE-2026-78677** `--separate-git-dir` missing from the clone denylist; **CVE-2026-78678** `Repo.blame()` accepts `--contents`/`-S` for arbitrary file read | 3.1.61 |
| `click` | 8.3.1 | CVE-2026-7246, command injection in `click.edit()` | 8.5.0 (lock only) |

The mkdocs-material XSS is live on tako-research.github.io/TakoVM today. GitPython arrives transitively through `mkdocs-git-revision-date-localized-plugin` and runs in docs CI over repository content, which is exactly the input those four CVEs are about.

`click` gets no floor of its own — it comes in under `mkdocs`, nothing in this repo calls `click.edit()`, and the lock moves it anyway.

## Why the workflow changed too

`docs.yml` installs with `pip install "mkdocs-material[imaging]" mkdocs-git-revision-date-localized-plugin` — unpinned, resolved at build time, never reading `uv.lock`. A lockfile bump on its own would not have changed one byte of the deployed site. The floors are duplicated into the workflow so the thing that actually builds the site is the thing that enforces them.

## Verification

- `mkdocs build --strict` → exit 0, builds in 4.3s
- `uv.lock` re-scanned against OSV: 82 packages, **0 advisories** (was 6)
- Runtime dependencies untouched; no version bump, since nothing here ships to PyPI

Worth noting separately: Dependabot reports 1 moderate on `main`, and there were 5. It isn't reading `uv.lock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LNCs7pNgSHTgrkKHQBTHRq